### PR TITLE
Remove dothash support

### DIFF
--- a/jekyll-spark.gemspec
+++ b/jekyll-spark.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency("jekyll", ">= 3.1.2")
   spec.add_runtime_dependency("htmlcompressor", "~> 0.3.1")
-  spec.add_runtime_dependency("dot_hash", "1.1.8")
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/jekyll/spark/base.rb
+++ b/lib/jekyll/spark/base.rb
@@ -1,7 +1,6 @@
 require "htmlcompressor"
 require "jekyll"
 require "liquid"
-require "dot_hash"
 
 module Jekyll
   module ComponentBase
@@ -70,8 +69,7 @@ module Jekyll
     end
 
     def set_props(props = Hash.new)
-      @props = DotHash.load(@props.merge(props))
-      # @context[@context_name] = @props
+      @props = @props.merge(props)
     end
 
     def serialize_data

--- a/test/test_unit_spark_base.rb
+++ b/test/test_unit_spark_base.rb
@@ -21,20 +21,6 @@ class SparkComponentBase < JekyllUnitTest
       assert_equal(o.props["name"], "Name")
     end
 
-    should "support dot hash" do
-      o = Object.new
-      o.extend(Jekyll::ComponentBase)
-      o.props = Hash.new
-
-      h = Hash.new
-      h["name"] = "Name"
-
-      o.set_props(h)
-
-      assert_equal(o.props["name"], "Name")
-      assert_equal(o.props.name, "Name")
-    end
-
     should "handle null key/values" do
       o = Object.new
       o.extend(Jekyll::ComponentBase)
@@ -48,7 +34,6 @@ class SparkComponentBase < JekyllUnitTest
       o.set_props(h)
 
       assert_equal(o.props["name"], "Name")
-      assert_equal(o.props.name, "Name")
     end
   end
 


### PR DESCRIPTION
## Updates

This update removes dothash. Although it works correctly in Spark's tests, it (for whatever reason) doesn't work well in our marketing site. I also can't seem to break it in Spark's unit tests.

To allow for our marketing site to use the latest version of Spark, we'll need to remove dothash.

This version needs to be minor bumped.

Resolves: https://github.com/helpscout/jekyll-spark/issues/1