### PR TITLE
Removes space between tags

### DIFF
--- a/jekyll-spark.gemspec
+++ b/jekyll-spark.gemspec
@@ -28,9 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "minitest-profile"
   spec.add_development_dependency "minitest", "~> 5.8"
-  spec.add_development_dependency "nokogiri", "~> 1.7.1"
   spec.add_development_dependency "rspec-mocks"
-  spec.add_development_dependency "jekyll-joule"
+  spec.add_development_dependency "jekyll-joule", "~> 0.2.0"
   spec.add_development_dependency "shoulda"
   spec.add_development_dependency "kramdown"
 end

--- a/lib/jekyll/spark/base.rb
+++ b/lib/jekyll/spark/base.rb
@@ -8,7 +8,9 @@ module Jekyll
     include Liquid::StandardFilters
 
     @@compressor = HtmlCompressor::Compressor.new({
-      :remove_comments => true
+      :remove_comments => true,
+      :remove_intertag_spaces => true,
+      :preserve_line_breaks => false,
     }).freeze
 
     def initialize(tag_name, markup, tokens)

--- a/test/test_component_image.rb
+++ b/test/test_component_image.rb
@@ -122,7 +122,7 @@ class ImageComponent < JekyllUnitTest
     markup = %Q[
       {% img
         srcset: "hello.png"
-        height: 100
+        height: 10
       %}
     ]
     @joule.render(markup)


### PR DESCRIPTION
## Removes space between tags

This commit adjusts the `htmlcompressor` settings to remove spacing
between tags. `jekyll-joule` was also updated to the latest version,
which includes Nokogiri.